### PR TITLE
[Feat] 러닝 기록 리스트 렌더링 및 localStorage 연동 완료

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -20,6 +20,30 @@
     padding: 1rem 0;
 }
 
+.sort-section {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.sort-section span {
+    font-size: 14px;
+    color: #808080;
+}
+
+.sort-section select {
+    padding: 0.3rem 0.5rem;
+    border-radius: 0.3rem;
+    border: 1px solid #ccc;
+    background-color: #f9f9f9;
+    cursor: pointer;
+}
+
+.sort-section select:focus {
+    outline: none;
+    border-color: #464646;
+}
+
 /* RecordForm */
 .form {
     display: flex;

--- a/src/App.css
+++ b/src/App.css
@@ -47,13 +47,8 @@
 }
 
 .form button {
-    padding: 0.5rem 1rem;
     background-color: #464646;
     color: white;
-    border: none;
-    border-radius: 0.3rem;
-    cursor: pointer;
-    font-weight: 500;
 }
 
 .form button:hover {
@@ -63,7 +58,6 @@
 /* RecordList */
 .record-list {
     background-color: #fcfcfc;
-    padding: 2rem 1.5rem;
     border: 1.5px solid #eee;
     border-radius: 0.5rem;
 
@@ -74,4 +68,68 @@
 
 .record-list .empty-message {
     color: #808080;
+    padding: 2rem 1.5rem;
+}
+
+.record-list-box {
+    width: 100%;
+}
+
+.record-list-header,
+.record-item {
+    display: grid;
+    grid-template-columns: 1.5fr 1fr 1fr 1fr 1fr 1fr;
+    gap: 10px;
+    align-items: center;
+    padding: 1rem;
+
+    border-bottom: 1px solid #eee;
+}
+
+.record-list-header {
+    font-weight: 700;
+}
+
+/* RecordItem */
+.record-item {
+    background-color: white;
+}
+
+.record-item div:first-child {
+    font-weight: 700;
+}
+
+.record-item .total span {
+    display: inline-block;
+    background-color: #eee5ff;
+    color: #7a007a;
+    font-size: 12px;
+    padding: 4px 8px;
+    border-radius: 30px;
+}
+
+.btn-section {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: center;
+}
+
+.edit-btn:hover {
+    background-color: #67b169;
+    color: white;
+}
+
+.delete-btn:hover {
+    background-color: #e05b66;
+    color: white;
+}
+
+/* 공통 */
+.btn {
+    padding: 0.5rem 1rem;
+    border: none;
+    border-radius: 0.3rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -8,13 +8,13 @@
 }
 
 /* RecordHeader */
-.header {
+.record-header {
     display: flex;
     align-items: center;
     justify-content: space-between;
 }
 
-.header h1 {
+.record-header h1 {
     font-size: 1.5rem;
     font-weight: 700;
     padding: 1rem 0;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,12 +2,15 @@ import './App.css';
 
 import RecordForm from './RecordForm';
 import RecordHeader from './RecordHeader';
+import { useState } from 'react';
 
 function App() {
+    const [sortBy, setSortBy] = useState('date');
+
     return (
         <div className="running-tracker-box">
-            <RecordHeader />
-            <RecordForm />
+            <RecordHeader sortBy={sortBy} setSortBy={setSortBy} />
+            <RecordForm sortBy={sortBy} />
         </div>
     );
 }

--- a/src/RecordForm.jsx
+++ b/src/RecordForm.jsx
@@ -77,7 +77,9 @@ const RecordForm = ({ sortBy }) => {
                     onChange={onChange}
                 />
 
-                <button type="submit">추가</button>
+                <button className="btn" type="submit">
+                    추가
+                </button>
             </form>
 
             <RecordList recordList={recordList} sortBy={sortBy} />

--- a/src/RecordForm.jsx
+++ b/src/RecordForm.jsx
@@ -34,6 +34,14 @@ const RecordForm = () => {
 
         console.log(record);
 
+        const existingRecords = recordList.filter((r) => r.date === record.date);
+
+        if (existingRecords.length) {
+            alert('같은 날짜가 이미 존재합니다.');
+            setRecord(initRecord);
+            return;
+        }
+
         setRecordList([...recordList, record]);
         setRecord(initRecord);
     };

--- a/src/RecordForm.jsx
+++ b/src/RecordForm.jsx
@@ -17,7 +17,7 @@ const initRecord = {
     rest: 0,
 };
 
-const RecordForm = () => {
+const RecordForm = ({ sortBy }) => {
     const [record, setRecord] = useState(initRecord);
     const [recordList, setRecordList] = useState([]);
 
@@ -80,7 +80,7 @@ const RecordForm = () => {
                 <button type="submit">추가</button>
             </form>
 
-            <RecordList recordList={recordList} />
+            <RecordList recordList={recordList} sortBy={sortBy} />
         </>
     );
 };

--- a/src/RecordForm.jsx
+++ b/src/RecordForm.jsx
@@ -19,10 +19,12 @@ const initRecord = {
 
 const RecordForm = ({ sortBy }) => {
     const [record, setRecord] = useState(initRecord);
-    const [recordList, setRecordList] = useState([]);
+    const [recordList, setRecordList] = useState(() => {
+        const savedRecords = localStorage.getItem('runningRecords'); // localStorage에서 기록 불러오기
+        return savedRecords ? JSON.parse(savedRecords) : [];
+    });
 
     const onChange = (e) => {
-        // console.log(e.target);
         const { name, value, type } = e.target;
 
         // type이 number면 문자열을 숫자로 변환하여 앞 0 제거
@@ -32,22 +34,24 @@ const RecordForm = ({ sortBy }) => {
     const onSubmit = (e) => {
         e.preventDefault(); // 새로고침 방지
 
-        console.log(record);
-
+        // 날짜 중복 체크
         const existingRecords = recordList.filter((r) => r.date === record.date);
-
         if (existingRecords.length) {
             alert('같은 날짜가 이미 존재합니다.');
             setRecord(initRecord);
             return;
         }
 
-        setRecordList([...recordList, record]);
+        // 기록 추가 및 localStorage 저장
+        const newList = [...recordList, record];
+        setRecordList(newList);
+        localStorage.setItem('runningRecords', JSON.stringify(newList));
+
         setRecord(initRecord);
     };
 
     return (
-        <>
+        <div>
             <form className="form" onSubmit={onSubmit}>
                 <Input type="date" id="date" name="date" label="📅 날짜" value={record.date} onChange={onChange} />
                 <Input
@@ -83,7 +87,7 @@ const RecordForm = ({ sortBy }) => {
             </form>
 
             <RecordList recordList={recordList} sortBy={sortBy} />
-        </>
+        </div>
     );
 };
 

--- a/src/RecordHeader.jsx
+++ b/src/RecordHeader.jsx
@@ -1,9 +1,27 @@
-const RecordHeader = () => {
+const RecordHeader = ({ sortBy, setSortBy }) => {
+    const options = [
+        { key: 'date', label: '날짜순' },
+        { key: 'total', label: '총 거리순' },
+        { key: 'running', label: '러닝순' },
+        { key: 'walking', label: '걸음순' },
+        { key: 'rest', label: '쉬는 시간순' },
+    ];
+
     return (
-        <header className="header">
+        <header className="record-header">
             <h1>👟 Running Tracker</h1>
 
-            <div>정렬</div>
+            <div className="sort-section">
+                <span>정렬 기준</span>
+
+                <select id="sort" value={sortBy} onChange={(e) => setSortBy(e.target.value)}>
+                    {options.map((opt) => (
+                        <option key={opt.key} value={opt.key}>
+                            {opt.label}
+                        </option>
+                    ))}
+                </select>
+            </div>
         </header>
     );
 };

--- a/src/RecordHeader.jsx
+++ b/src/RecordHeader.jsx
@@ -1,10 +1,10 @@
 const RecordHeader = ({ sortBy, setSortBy }) => {
     const options = [
-        { key: 'date', label: '날짜순' },
-        { key: 'total', label: '총 거리순' },
-        { key: 'running', label: '러닝순' },
-        { key: 'walking', label: '걸음순' },
-        { key: 'rest', label: '쉬는 시간순' },
+        { key: 'date', label: '날짜' },
+        { key: 'total', label: '총 거리' },
+        { key: 'running', label: '러닝' },
+        { key: 'walking', label: '워킹' },
+        { key: 'rest', label: '휴식' },
     ];
 
     return (

--- a/src/RecordItem.jsx
+++ b/src/RecordItem.jsx
@@ -8,7 +8,7 @@ const RecordItem = ({ record }) => {
             <div>{walking}</div>
             <div>{rest}</div>
             <div className="total">
-                <span>{running + walking}</span>
+                <span>{(running + walking).toFixed(1)}</span>
             </div>
             <div className="btn-section">
                 <button className="btn edit-btn">수정</button>

--- a/src/RecordItem.jsx
+++ b/src/RecordItem.jsx
@@ -3,7 +3,7 @@ const RecordItem = ({ record }) => {
 
     return (
         <li>
-            {date} | {running}km | {walking}km | {rest}분
+            {date} | {running}km | {walking}km | {rest}분 | 총거리 {running + walking}km
         </li>
     );
 };

--- a/src/RecordItem.jsx
+++ b/src/RecordItem.jsx
@@ -2,9 +2,19 @@ const RecordItem = ({ record }) => {
     const { date, running, walking, rest } = record;
 
     return (
-        <li>
-            {date} | {running}km | {walking}km | {rest}분 | 총거리 {running + walking}km
-        </li>
+        <div className="record-item">
+            <div>{date}</div>
+            <div>{running}</div>
+            <div>{walking}</div>
+            <div>{rest}</div>
+            <div className="total">
+                <span>{running + walking}</span>
+            </div>
+            <div className="btn-section">
+                <button className="btn edit-btn">수정</button>
+                <button className="btn delete-btn">삭제</button>
+            </div>
+        </div>
     );
 };
 

--- a/src/RecordList.jsx
+++ b/src/RecordList.jsx
@@ -27,11 +27,20 @@ const RecordList = ({ recordList, sortBy }) => {
             {!recordList.length ? (
                 <div className="empty-message">아직 기록이 없습니다. 날짜와 거리를 입력해 첫 기록을 추가해보세요!</div>
             ) : (
-                <ul>
+                <div className="record-list-box">
+                    <div className="record-list-header">
+                        <div>날짜</div>
+                        <div>러닝(km)</div>
+                        <div>워킹(km)</div>
+                        <div>휴식(분)</div>
+                        <div>총합(km)</div>
+                        <div>작업</div>
+                    </div>
+
                     {sortedList.map((record, index) => (
                         <RecordItem key={index} record={record} />
                     ))}
-                </ul>
+                </div>
             )}
         </div>
     );

--- a/src/RecordList.jsx
+++ b/src/RecordList.jsx
@@ -1,13 +1,34 @@
 import RecordItem from './RecordItem';
 
-const RecordList = ({ recordList }) => {
+const RecordList = ({ recordList, sortBy }) => {
+    const getSortList = () => {
+        const sorted = [...recordList];
+
+        switch (sortBy) {
+            case 'date':
+                return sorted.sort((a, b) => new Date(b.date) - new Date(a.date));
+            case 'total':
+                return sorted.sort((a, b) => b.running + b.walking - (a.running + a.walking));
+            case 'running':
+                return sorted.sort((a, b) => b.running - a.running);
+            case 'walking':
+                return sorted.sort((a, b) => b.walking - a.walking);
+            case 'rest':
+                return sorted.sort((a, b) => b.rest - a.rest);
+            default:
+                return sorted;
+        }
+    };
+
+    const sortedList = getSortList();
+
     return (
         <div className="record-list">
-            {recordList.length === 0 ? (
+            {!recordList.length ? (
                 <div className="empty-message">아직 기록이 없습니다. 날짜와 거리를 입력해 첫 기록을 추가해보세요!</div>
             ) : (
                 <ul>
-                    {recordList.map((record, index) => (
+                    {sortedList.map((record, index) => (
                         <RecordItem key={index} record={record} />
                     ))}
                 </ul>


### PR DESCRIPTION
## 🎯 TODO

- [x]  `RecordList`와 `RecordItem`에 Grid 레이아웃 적용
- [x]  같은 날짜 중복 입력 방지 기능 구현
- [x]  기록 정렬 기능 추가
    - 날짜, 총 거리, 러닝, 워킹, 휴식 순
- [x]  `localStorage` 연동
    - 기록 추가 시 `localStorage`에 저장
    - 앱 시작 시 기존 기록 불러오기, 없으면 안내 문구 표시

---

### 🚨 총 거리 합계 소수점 문제 발생
- 러닝, 워킹 합계를 계산할 때 `0.1 + 0.2 = 0.30000000000000004` 처럼 부동소수점 오류 발생

    <img width="1444" height="708" alt="image" src="https://github.com/user-attachments/assets/64fcca6d-0322-4cc1-9d62-cba0f82048d8" />
    
  - 0.1, 0.2 같은 소수를 더할 때 내부적으로 이진수로 변환되며 오차가 생길 수 있음

**해결**

- `toFixed(1)` 사용
    
    ```jsx
    <div className="total">
      <span>{(running + walking).toFixed(1)}</span>
    </div>
    ```
    
    - 합계를 소수점 한 자리로 고정하여 표시
  
  <img width="1451" height="714" alt="image" src="https://github.com/user-attachments/assets/ef709ebf-2287-45c0-812b-2f12f2d10018" />

---

## 💻 결과
- 이미 존재하는 날짜 추가 시

  <img width="1695" height="1104" alt="image" src="https://github.com/user-attachments/assets/a4990402-d355-470e-8eb7-7ae8022a0f1f" />

- 정렬 → 날짜 순

  <img width="1881" height="1103" alt="image" src="https://github.com/user-attachments/assets/265fed45-01c0-4518-8351-2a17fdfadd3e" />

- 정렬 총 거리 순

  <img width="1791" height="1079" alt="image" src="https://github.com/user-attachments/assets/474c7602-634b-4ad1-8ba6-dcf869d45ff5" />


---

## 🗓️ 다음 할 일
- 러닝 기록 리스트 렌더링 및 localStorage 연동
