### PR TITLE
[Feat] 수정(Update) 및 삭제(Delete) 기능 구현 완료

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -123,6 +123,13 @@
     font-weight: 700;
 }
 
+.record-item input {
+    padding: 0.5rem;
+    border: 1.5px solid #eee;
+    border-radius: 0.3rem;
+    width: 120px;
+}
+
 .record-item .total span {
     display: inline-block;
     background-color: #eee5ff;
@@ -136,6 +143,19 @@
     display: flex;
     gap: 0.5rem;
     justify-content: center;
+}
+
+.save-btn {
+    background-color: #464646;
+    color: white;
+}
+
+.save-btn:hover {
+    background-color: #000000;
+}
+
+.cancel-btn:hover {
+    background-color: #eee5ff;
 }
 
 .edit-btn:hover {

--- a/src/RecordForm.jsx
+++ b/src/RecordForm.jsx
@@ -12,11 +12,18 @@ const initRecord = {
 const RecordForm = ({ sortBy }) => {
     const [record, setRecord] = useState(initRecord);
 
-    // localStorage에서 기록 불러오기
-    const [recordList, setRecordList] = useState(() => {
+    // localStorage 처리 함수
+    const loadRecords = () => {
         const savedRecords = localStorage.getItem('runningRecords');
         return savedRecords ? JSON.parse(savedRecords) : [];
-    });
+    };
+
+    const saveRecords = (records) => {
+        localStorage.setItem('runningRecords', JSON.stringify(records));
+    };
+
+    // localStorage에서 기록 불러오기
+    const [recordList, setRecordList] = useState(loadRecords());
 
     // 입력값 변경 시
     const onChange = (e) => {
@@ -38,11 +45,10 @@ const RecordForm = ({ sortBy }) => {
             return;
         }
 
-        // 기록 추가 및 localStorage 저장
         const newList = [...recordList, record];
-        setRecordList(newList);
-        localStorage.setItem('runningRecords', JSON.stringify(newList));
 
+        setRecordList(newList);
+        saveRecords(newList); // 로컬 스토리지 저장
         setRecord(initRecord);
     };
 
@@ -53,7 +59,7 @@ const RecordForm = ({ sortBy }) => {
         });
 
         setRecordList(newList);
-        localStorage.setItem('runningRecords', JSON.stringify(newList));
+        saveRecords(newList); // 로컬 스토리지 저장
     };
 
     // 기록 삭제
@@ -63,7 +69,7 @@ const RecordForm = ({ sortBy }) => {
 
         const newList = recordList.filter((record) => record.date !== date);
         setRecordList(newList);
-        localStorage.setItem('runningRecords', JSON.stringify(newList));
+        saveRecords(newList); // 로컬 스토리지 저장
     };
 
     return (

--- a/src/RecordForm.jsx
+++ b/src/RecordForm.jsx
@@ -1,14 +1,6 @@
+import Input from './components/Input';
 import RecordList from './RecordList';
 import { useState } from 'react';
-
-const Input = ({ type, id, name, label, value, onChange, step }) => {
-    return (
-        <label htmlFor={id}>
-            <span>{label}</span>
-            <input type={type} id={id} name={name} value={value} onChange={onChange} min={0} step={step} required />
-        </label>
-    );
-};
 
 const initRecord = {
     date: '',

--- a/src/RecordForm.jsx
+++ b/src/RecordForm.jsx
@@ -56,6 +56,16 @@ const RecordForm = ({ sortBy }) => {
         localStorage.setItem('runningRecords', JSON.stringify(newList));
     };
 
+    // 기록 삭제
+    const onDelete = (date) => {
+        const confirmMessage = window.confirm('정말 삭제하시겠습니까?'); // 사용자 확인
+        if (!confirmMessage) return;
+
+        const newList = recordList.filter((record) => record.date !== date);
+        setRecordList(newList);
+        localStorage.setItem('runningRecords', JSON.stringify(newList));
+    };
+
     return (
         <div>
             <form className="form" onSubmit={onSubmit}>
@@ -92,7 +102,7 @@ const RecordForm = ({ sortBy }) => {
                 </button>
             </form>
 
-            <RecordList recordList={recordList} sortBy={sortBy} onUpdate={onUpdate} />
+            <RecordList recordList={recordList} sortBy={sortBy} onUpdate={onUpdate} onDelete={onDelete} />
         </div>
     );
 };

--- a/src/RecordForm.jsx
+++ b/src/RecordForm.jsx
@@ -19,11 +19,14 @@ const initRecord = {
 
 const RecordForm = ({ sortBy }) => {
     const [record, setRecord] = useState(initRecord);
+
+    // localStorage에서 기록 불러오기
     const [recordList, setRecordList] = useState(() => {
-        const savedRecords = localStorage.getItem('runningRecords'); // localStorage에서 기록 불러오기
+        const savedRecords = localStorage.getItem('runningRecords');
         return savedRecords ? JSON.parse(savedRecords) : [];
     });
 
+    // 입력값 변경 시
     const onChange = (e) => {
         const { name, value, type } = e.target;
 
@@ -31,6 +34,7 @@ const RecordForm = ({ sortBy }) => {
         setRecord({ ...record, [name]: type === 'number' ? Number(value) : value });
     };
 
+    // 기록 추가
     const onSubmit = (e) => {
         e.preventDefault(); // 새로고침 방지
 
@@ -48,6 +52,16 @@ const RecordForm = ({ sortBy }) => {
         localStorage.setItem('runningRecords', JSON.stringify(newList));
 
         setRecord(initRecord);
+    };
+
+    // 기록 수정
+    const onUpdate = (date, updatedData) => {
+        const newList = recordList.map((record) => {
+            return record.date === date ? { ...record, ...updatedData } : record;
+        });
+
+        setRecordList(newList);
+        localStorage.setItem('runningRecords', JSON.stringify(newList));
     };
 
     return (
@@ -86,7 +100,7 @@ const RecordForm = ({ sortBy }) => {
                 </button>
             </form>
 
-            <RecordList recordList={recordList} sortBy={sortBy} />
+            <RecordList recordList={recordList} sortBy={sortBy} onUpdate={onUpdate} />
         </div>
     );
 };

--- a/src/RecordItem.jsx
+++ b/src/RecordItem.jsx
@@ -1,7 +1,7 @@
 import Input from './components/Input';
 import { useState } from 'react';
 
-const RecordItem = ({ record, onUpdate }) => {
+const RecordItem = ({ record, onUpdate, onDelete }) => {
     const { date, running, walking, rest } = record;
 
     const [isEditing, setIsEditing] = useState(false); // 수정 상태
@@ -86,7 +86,9 @@ const RecordItem = ({ record, onUpdate }) => {
                         >
                             수정
                         </button>
-                        <button className="btn delete-btn">삭제</button>
+                        <button className="btn delete-btn" onClick={() => onDelete(date)}>
+                            삭제
+                        </button>
                     </>
                 )}
             </div>

--- a/src/RecordItem.jsx
+++ b/src/RecordItem.jsx
@@ -1,18 +1,63 @@
-const RecordItem = ({ record }) => {
+import { useState } from 'react';
+
+const RecordItem = ({ record, onUpdate }) => {
     const { date, running, walking, rest } = record;
+
+    const [isEditing, setIsEditing] = useState(false); // 수정 상태
+    const [editedRecord, setEditedRecord] = useState({ running, walking, rest }); // 수정할 데이터
+
+    // 입력값 변경 시
+    const onChange = (e) => {
+        const { name, value } = e.target;
+        setEditedRecord((prev) => ({ ...prev, [name]: Number(value) }));
+    };
+
+    // 저장 버튼 클릭 시
+    const onSave = () => {
+        onUpdate(date, editedRecord);
+        setIsEditing(false);
+    };
 
     return (
         <div className="record-item">
             <div>{date}</div>
-            <div>{running}</div>
-            <div>{walking}</div>
-            <div>{rest}</div>
+
+            {isEditing ? (
+                <>
+                    <input type="number" name="running" value={editedRecord.running} onChange={onChange} step="0.1" />
+                    <input type="number" name="walking" value={editedRecord.walking} onChange={onChange} step="0.1" />
+                    <input type="number" name="rest" value={editedRecord.rest} onChange={onChange} />
+                </>
+            ) : (
+                <>
+                    <div>{running}</div>
+                    <div>{walking}</div>
+                    <div>{rest}</div>
+                </>
+            )}
+
             <div className="total">
                 <span>{(running + walking).toFixed(1)}</span>
             </div>
+
             <div className="btn-section">
-                <button className="btn edit-btn">수정</button>
-                <button className="btn delete-btn">삭제</button>
+                {isEditing ? (
+                    <>
+                        <button className="btn save-btn" onClick={onSave}>
+                            저장
+                        </button>
+                        <button className="btn cancel-btn" onClick={() => setIsEditing(false)}>
+                            취소
+                        </button>
+                    </>
+                ) : (
+                    <>
+                        <button className="btn edit-btn" onClick={() => setIsEditing(true)}>
+                            수정
+                        </button>
+                        <button className="btn delete-btn">삭제</button>
+                    </>
+                )}
             </div>
         </div>
     );

--- a/src/RecordItem.jsx
+++ b/src/RecordItem.jsx
@@ -1,3 +1,4 @@
+import Input from './components/Input';
 import { useState } from 'react';
 
 const RecordItem = ({ record, onUpdate }) => {
@@ -24,9 +25,23 @@ const RecordItem = ({ record, onUpdate }) => {
 
             {isEditing ? (
                 <>
-                    <input type="number" name="running" value={editedRecord.running} onChange={onChange} step="0.1" />
-                    <input type="number" name="walking" value={editedRecord.walking} onChange={onChange} step="0.1" />
-                    <input type="number" name="rest" value={editedRecord.rest} onChange={onChange} />
+                    <Input
+                        type="number"
+                        id="running"
+                        name="running"
+                        value={editedRecord.running}
+                        onChange={onChange}
+                        step="0.1"
+                    />
+                    <Input
+                        type="number"
+                        id="walking"
+                        name="walking"
+                        value={editedRecord.walking}
+                        onChange={onChange}
+                        step="0.1"
+                    />
+                    <Input type="number" id="rest" name="rest" value={editedRecord.rest} onChange={onChange} />
                 </>
             ) : (
                 <>

--- a/src/RecordItem.jsx
+++ b/src/RecordItem.jsx
@@ -52,7 +52,11 @@ const RecordItem = ({ record, onUpdate }) => {
             )}
 
             <div className="total">
-                <span>{(running + walking).toFixed(1)}</span>
+                <span>
+                    {(
+                        (isEditing ? editedRecord.running : running) + (isEditing ? editedRecord.walking : walking)
+                    ).toFixed(1)}
+                </span>
             </div>
 
             <div className="btn-section">
@@ -61,13 +65,25 @@ const RecordItem = ({ record, onUpdate }) => {
                         <button className="btn save-btn" onClick={onSave}>
                             저장
                         </button>
-                        <button className="btn cancel-btn" onClick={() => setIsEditing(false)}>
+                        <button
+                            className="btn cancel-btn"
+                            onClick={() => {
+                                setEditedRecord({ running, walking, rest }); // 최신값으로 세팅
+                                setIsEditing(false);
+                            }}
+                        >
                             취소
                         </button>
                     </>
                 ) : (
                     <>
-                        <button className="btn edit-btn" onClick={() => setIsEditing(true)}>
+                        <button
+                            className="btn edit-btn"
+                            onClick={() => {
+                                setEditedRecord({ running, walking, rest }); // 최신값으로 세팅
+                                setIsEditing(true);
+                            }}
+                        >
                             수정
                         </button>
                         <button className="btn delete-btn">삭제</button>

--- a/src/RecordItem.jsx
+++ b/src/RecordItem.jsx
@@ -7,6 +7,9 @@ const RecordItem = ({ record, onUpdate, onDelete }) => {
     const [isEditing, setIsEditing] = useState(false); // 수정 상태
     const [editedRecord, setEditedRecord] = useState({ running, walking, rest }); // 수정할 데이터
 
+    // 총 거리 합
+    const total = (isEditing ? editedRecord.running : running) + (isEditing ? editedRecord.walking : walking);
+
     // 입력값 변경 시
     const onChange = (e) => {
         const { name, value } = e.target;
@@ -52,11 +55,7 @@ const RecordItem = ({ record, onUpdate, onDelete }) => {
             )}
 
             <div className="total">
-                <span>
-                    {(
-                        (isEditing ? editedRecord.running : running) + (isEditing ? editedRecord.walking : walking)
-                    ).toFixed(1)}
-                </span>
+                <span>{total.toFixed(1)}</span>
             </div>
 
             <div className="btn-section">

--- a/src/RecordList.jsx
+++ b/src/RecordList.jsx
@@ -1,6 +1,6 @@
 import RecordItem from './RecordItem';
 
-const RecordList = ({ recordList, sortBy }) => {
+const RecordList = ({ recordList, sortBy, onUpdate }) => {
     const getSortList = () => {
         const sorted = [...recordList];
 
@@ -38,7 +38,7 @@ const RecordList = ({ recordList, sortBy }) => {
                     </div>
 
                     {sortedList.map((record, index) => (
-                        <RecordItem key={index} record={record} />
+                        <RecordItem key={index} record={record} onUpdate={onUpdate} />
                     ))}
                 </div>
             )}

--- a/src/RecordList.jsx
+++ b/src/RecordList.jsx
@@ -1,6 +1,6 @@
 import RecordItem from './RecordItem';
 
-const RecordList = ({ recordList, sortBy, onUpdate }) => {
+const RecordList = ({ recordList, sortBy, onUpdate, onDelete }) => {
     const getSortList = () => {
         const sorted = [...recordList];
 
@@ -38,7 +38,7 @@ const RecordList = ({ recordList, sortBy, onUpdate }) => {
                     </div>
 
                     {sortedList.map((record, index) => (
-                        <RecordItem key={index} record={record} onUpdate={onUpdate} />
+                        <RecordItem key={index} record={record} onUpdate={onUpdate} onDelete={onDelete} />
                     ))}
                 </div>
             )}

--- a/src/components/Input.jsx
+++ b/src/components/Input.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const Input = ({ type, id, name, label, value, onChange, step }) => {
+    return (
+        <label htmlFor={id}>
+            <span>{label}</span>
+            <input type={type} id={id} name={name} value={value} onChange={onChange} min={0} step={step} required />
+        </label>
+    );
+};
+
+export default Input;


### PR DESCRIPTION
## 🎯 TODO

- [x]  **수정(Update) 기능**
    - RecordItem에서 수정 모드(isEditing) 추가
    - 수정된 값 onUpdate를 통해 상위 컴포넌트로 전달
    - RecordForm에서 localStorage 동기화
- [x]  **삭제(Delete) 기능**
    - 각 기록 항목에 “삭제” 버튼을 추가
    - 클릭 시 해당 날짜의 기록을 삭제
    - 배열의 filter() 메서드를 사용
- [x]  **로컬 스토리지 연동**
    - 수정, 삭제 모두 로컬스토리지에 연동

---

### 🚨 RecordItem 수정/취소 버튼 클릭 시 데이터 동기화 문제
**문제 상황**
- 특정 기록의 `수정` 버튼을 누르면, 값이 같이 변경되거나 화면에 잘못 표시되는 현상 발생
- 취소 버튼 클릭 후 다음 수정 시 이전 입력 값이 남아 있음

**원인**
- `editedRecord` 상태를 `useState`로 초기화할 때 **컴포넌트 최초 렌더링 시 한 번만** 실행됨
- 이후 `record` prop이 바뀌어도 `editedRecord`는 자동으로 업데이트되지 않음
- 따라서 수정 모드 진입 시 이전 값이나 다른 레코드 값이 반영되는 현상이 발생

**해결**

- **수정 버튼** 클릭 시: 최신 `record` 값으로 `editedRecord` 초기화
- **취소 버튼** 클릭 시: `editedRecord`를 현재 `record` 값으로 되돌림

```jsx
{/* 수정 버튼 */}
<button
  onClick={() => {
    setEditedRecord({ running, walking, rest }); // 최신값으로 초기화
    setIsEditing(true);
  }}
>
  수정
</button>

{/* 취소 버튼 */}
<button
  onClick={() => {
    setEditedRecord({ running, walking, rest }); // 원래 값으로 되돌림
    setIsEditing(false);
  }}
>
  취소
</button>
```

---

## 💻 결과
- `수정` 버튼 클릭 시
    
    <img width="1680" height="1057" alt="image" src="https://github.com/user-attachments/assets/cec95c09-9a38-4366-a335-4f4a5e22aea0" />
    
    - `취소` 버튼 누르면, 원래 상태로 돌아감
    - `저장` 버튼 누르면, 바뀐 값으로 저장

---

- `삭제` 버튼 클릭 시
    
    <img width="1671" height="1120" alt="image" src="https://github.com/user-attachments/assets/5179caab-dba1-4d22-9389-75e0d122ff67" />
    
    - 한 번 더 확인하는 창을 띄우고 확인 눌러야 삭제

